### PR TITLE
feat(enhanced-search): search by title, city, type and owner

### DIFF
--- a/app/components/rentals/filter.ts
+++ b/app/components/rentals/filter.ts
@@ -6,13 +6,24 @@ interface RentalsFilterSignature {
   query: string;
 }
 
+type RentalModelKey = keyof RentalModel;
+
 export default class RentalsFilterComponent extends Component<RentalsFilterSignature> {
   get results() {
     let { rentals, query } = this.args;
-    if (query) {
+    query = query.toLowerCase();
+    if (query.length > 2) {
       rentals = rentals.filter((rental) => {
-        const matches = rental.title.includes(query);
-        return matches;
+        const propertiesToMatch = ['title', 'city', 'type', 'owner'];
+        for (const property of propertiesToMatch) {
+          const matches = (rental[property as RentalModelKey] as string)
+            .toLowerCase()
+            .includes(query);
+          if (matches) {
+            return true;
+          }
+        }
+        return false;
       });
     }
 


### PR DESCRIPTION
# Goal
Resolves #10 and part of #2 

- Adds enhanced search
- Allow for searching for rentals to include not just title but also title regardless of case, owner name, type (community or standalone) and or location (city)
- Search begins only when you have more than 2 characters typed

<img width="1305" alt="image" src="https://github.com/nelsonomuto/power-auctions-ember-app/assets/1546207/05d09e0e-88d6-46b0-a262-f97d30ffda47">
